### PR TITLE
Changing Server Profile docs

### DIFF
--- a/99-helper-scripts/build-server-profile.sh
+++ b/99-helper-scripts/build-server-profile.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env sh
+TOOL_NAME=$( basename "${0}" )
+cd "$( dirname "${0}" )" || exit 1
+
+availableProducts="pingfederate pingaccess pingdirectory pingdatasync"
+containerInstancePath="/opt/out/instance"
+
+##########################################################################################
+usage ()
+{
+	if ! test -z "${1}" ; then
+       echo "-------------------------------------------------------------------------"
+	   echo "Error: ${1}"
+       echo "-------------------------------------------------------------------------"
+	fi
+
+	cat <<END_USAGE1
+Usage: ${TOOL_NAME} {options}
+    where {options} include:
+       *-p, --product {product}
+END_USAGE1
+
+	for prodName in ${availableProducts}; do
+	    echo "                            ${prodName}"
+	done
+    
+	cat <<END_USAGE2
+        -t : build from a template
+        -c, --container {docker container}: build from a container
+        -i, --instance {path}:  build from a local instance
+
+        -o, --ouptut-dir {path}: Directory to create new server-profile
+                                 Default: /tmp/server-profiile-{pid}
+
+        -d : Turn on script debugging
+END_USAGE2
+	exit 77
+}
+
+##########################################################################################
+# Build PingFederate
+##########################################################################################
+buildPingFederateServerProfile()
+{
+    echo "Building PingFederate Server Profile"
+    
+    mkdir -p "${outputDir}/bin"
+    mkdir -p "${outputDir}/etc"
+    mkdir -p "${outputDir}/server/default/conf"
+    mkdir -p "${outputDir}/server/default/data/drop-in-deployer"
+
+    echo "Getting..."
+    echo "    bin files (probably only need .properties and .xml files)........"
+    docker cp "${dockerContainerId}:${containerInstancePath}/bin" "${outputDir}"
+
+    echo "    etc files..."
+    docker cp "${dockerContainerId}:${containerInstancePath}/etc" "${outputDir}"
+
+    echo "    conf files (a ton of stuff, templates, l18n message files........"
+    docker cp "${dockerContainerId}:${containerInstancePath}/server/default/conf" "${outputDir}/server/default"
+
+    echo "    latest data.zip"
+    lastestDataArchive=$( docker exec "${dockerContainerId}" ls -Art "${containerInstancePath}/server/default/data/archive"  | tail -1 )
+    echo "Getting ${lastestDataArchive}"
+    docker cp "${dockerContainerId}:${containerInstancePath}/server/default/data/archive/${lastestDataArchive}" "${outputDir}/server/default/data/drop-in-deployer/data.zip"
+
+    # BELOW REPRESENTS SOME IDEAS TO BUILD UP ON CONTAINER FIRST
+    # docker cp local-build.sh  up to the container
+    # docker exec -it ${containerId} /opt/build-server-profile
+    # docker cp ${dockerContainerId}} /opt/scripts/server-profile /tmp/.
+
+}
+
+##########################################################################################
+# Build PingAccess
+##########################################################################################
+buildPingAccessServerProfile()
+{
+    echo "Building PingAccess Server Profile"
+    echo "Yet to be implemented"
+
+    # An option if curling from external
+    # curl -k -u administrator:2FederateM0re -H "Content-type: application/json" https://lic.pingaccess.devops.gte:9000/pa-admin-api/v3/config/export > output.json
+    # docker cp ${dockerContainerId}:/opt/out/instance/data/archive/latest.data.zip /tmp
+    # unzip -d "${serverPofilePath}" /tmp/latest.data.zip
+    # Potential Templates
+    # log4j
+    # run.properties
+
+}
+
+##########################################################################################
+# Build PingDirectory
+##########################################################################################
+buildPingDirectoryServerProfile()
+{
+    echo "Building PingDirectory Server Profile"
+    echo "Yet to be implemented"
+}
+
+##########################################################################################
+# Build PingAccess
+##########################################################################################
+buildPingDataSyncServerProfile()
+{
+    echo "Building PingDataSync Server Profile"
+    echo "Yet to be implemented"
+}
+
+##########################################################################################
+outputDir="/tmp/server-profile-$$"
+product=""
+dockerContainerId=""
+instancePath=""
+while ! test -z "${1}" ; do
+    case "${1}" in
+        -p|--product)
+			shift
+			test -z "${1}" && usage "Product argument missing"
+			
+			# lowercase the argument value (the product name )
+			product=$( echo ${1} | tr [A-Z] [a-z] )
+
+	        for prodName in ${availableProducts}; do
+	            if test "${product}" = "${prodName}" ; then
+				    foundProduct=true
+				fi
+	        done
+			;;
+		-c|--container)
+			shift
+			test -z "${1}" && usage "Container id/name missing"
+			containerId=${1}
+            dockerContainerId=$( docker ps -q -f name=${containerId} )
+            test ! -z "${dockerContainerId}" || dockerContainerId=$( docker ps -q -f id=${containerId} )
+            test ! -z "${dockerContainerId}" || usage "Unable to find locally running docker container '${containerId}'"
+            echo "Using container: ${dockerContainerId}"
+			;;
+		-i|--instance)
+			shift
+			test -z "${1}" && usage "Instance path missing"
+			instancePath=${1}
+            test -d "${instancePath}" || usage "Path '${instancePath}' not found"
+			;;
+		-o|--output-dir)
+			shift
+			test -z "${1}" && usage "output-dir path missing"
+			outputDir=${1}
+            test -d "${outputDir}" && usage "Output Directory '${outputDir}' exists.  Please provide new path"
+            ;;
+		-d|--debug)
+			set -x
+			;;
+		*)
+			usage
+			;;
+	esac
+    shift
+done
+
+# Check combination of options
+test ! -z "${dockerContainerId}" && test ! -z "${instancePath}" && usage "Only a container or instance can be used"
+test -z "${product}" && usage "Product name required"
+
+echo "
+###############################################################################################
+# Building Server Profile
+###############################################################################################
+#
+#      Product: ${product}
+#    Container: ${containerId}
+#   Output Dir: ${outputDir}
+#
+###############################################################################################
+
+"
+mkdir -p "${outputDir}"
+			
+case ${product} in
+    "pingfederate")
+       buildPingFederateServerProfile
+       ;;
+    "pingaccess")
+       buildPingAccessServerProfile
+       ;;
+    "pingdirectory")
+       buildPingDirectoryServerProfile
+       ;;
+    "pingdatasync")
+       buildPingDataSyncServerProfile
+       ;;
+esac
+
+
+exit
+
+
+
+#!/usr/bin/env sh
+if test -z "${1}" ; then
+    echo the first argument must be a container id
+    exit 1
+fi
+
+if test -z "${2}" ; then
+    echo "The second argument must the path to the server profile"
+    exit 2
+fi
+
+if ! test -d "${2}" ; then
+  echo the path to the server profile does not exist
+  exit 3
+fi
+
+if ! test $(basename "${2}") = "instance" ; then
+    echo "the server profile path should end with 'instance' (i.e. </path/to/pa-server-profile>/instance)"
+    exit 4
+fi
+containerId="${1}"
+serverPofilePath="${2}"

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,7 +25,7 @@
   * [Kubernetes Minikube](20-kubernetes-minikube/README.md)
   * [Kubernetes AWS](21-kubernetes-amazon/README.md)
 * [Server Profiles](docs/server-profiles/README.md)
-  * [Definitions](docs/server-profiles/ADMINISTRATION.md)
+  * [Administration](docs/server-profiles/ADMINISTRATION.md)
   * [Quick Start](docs/server-profiles/QUICKSTART.md)
   * [Getting Started](docs/server-profiles/GETTING_STARTED.md)
   * [Baseline](docs/server-profiles/BASELINE.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -25,6 +25,7 @@
   * [Kubernetes Minikube](20-kubernetes-minikube/README.md)
   * [Kubernetes AWS](21-kubernetes-amazon/README.md)
 * [Server Profiles](docs/server-profiles/README.md)
+  * [Definitions](docs/server-profiles/ADMINISTRATION.md)
   * [Quick Start](docs/server-profiles/QUICKSTART.md)
   * [Getting Started](docs/server-profiles/GETTING_STARTED.md)
   * [Baseline](docs/server-profiles/BASELINE.md)

--- a/bash_profile_docker
+++ b/bash_profile_docker
@@ -40,6 +40,13 @@ cat <<EOHELP
  dvp - prune               dnp - prune
  dvr - remove              dnr - remove
 
+ ${bold}Docker Compose${normal}
+ ------------------------
+ dpu - up (detached)
+ dpd - down
+ dpp - ps
+ dpl - logs (w/ -f)
+
  ${bold}Special${normal}
  ----------------------------------------------------------------------------
  ddc - deep clean (cont, vol, net)
@@ -102,6 +109,12 @@ alias dnr="run docker network rm"
 alias dsl="run docker service ls"
 alias dss="run docker service scale"
 alias dsr="run docker service rm"
+
+## docker-compose
+alias dpu="run docker-compose up -d"
+alias dpd="run docker-compose down"
+alias dpp="run docker-compose ps"
+alias dpl="run docker-compose logs -f"
 
 ## logs
 alias dlf="run docker logs -f"

--- a/docs/server-profiles/ADMINISTRATION.md
+++ b/docs/server-profiles/ADMINISTRATION.md
@@ -1,0 +1,87 @@
+# Ping Identity Server Profiles
+This document explains how server profiles work for Ping Identity Docker images
+
+## What's in it?
+Server profiles aim at providing a common convention to adapt the common images into workable containers in all circumstances.
+
+## Layout
+### PingFederate
+- `instance`
+    Place any file that need to be present with the runtime of the product, in accordance with the file layout of the product.
+    - Some examples:
+        - `instance/server/default/data/drop-in-deployer/data.zip` can be used to apply a configuration archive exported to a container.
+        This can be convenient when going from a PingFederate instance to deployed PingFederate containers
+        - `server/default/deploy/OAuthPlayground.war`
+        automatically deploy the OAuthPlayground web application
+        - `instance/server/default/conf/pingfederate.lic`
+        inject a PingFederate license into the running container
+        - `instance/server/default/conf/META-INF/hivemodule.xml`
+        apply a hivemodule configuration to the container
+
+### PingAccess
+- `instance`
+    Place any file that needs to be present with the runtime of the product, in accordance  with the file layout of the product.
+
+### PingDirectory
+- `dsconfig`
+    Provide dsconfig configuration fragments.
+When the container starts, all the fragments are appended in the order in which they are numbered and applied in one large batch.
+Files must be named with two digits, a dash, a label, and with the .dsconfig extension (i.e. 12-index-oauth-grants.dsconfig).
+
+- `data`
+    Provide ldif data fragments.
+When the container starts, all the provided files are imported in the order in which they're named.
+Files must be named with two digits, a dash, the backend name (the default is userRoot), a label, and with the .ldif extension for plain LDIF or .ldif.gz for a gzip compressed file
+For example:
+    - `10-userRoot-skeleton.ldif`
+    - `20-userRoot-users.ldif.gz`
+    - `30-userRoot-groups.ldif`
+- `hooks`
+    In this directory you can put a set of custom scripts that will be called at key points during the container startup sequence.
+    - On every container start event:
+        - `00-immediate-startup.sh` is called immediately upon container startup
+    - The first time a container starts:
+        - `10-before-copying-bits.sh` is called 
+        - `20-before-setup.sh` is called immediately before the setup tool is executed
+        - `30-before-configuration.sh` is called immediately before the dsconfig tool is executed
+        - `40-before-import.sh` is called immediately before the import-ldif is executed
+    - On every container start event:
+        - `50-before-post-start.sh` is called before the built-in postStart.sh script is executed in the background
+        - `80-post-start.sh` is called instead of the built-in postStart.sh script if it is provided
+
+- `instance`
+    Place any file that needs to be present with the runtime of the product, in accordance with the file layout of the product.
+    - You can place custom schema in `instance/config/schema/`
+    - You can provide your certificates in a JKS keystore with these two files:
+        `instance/config/keystore`
+        `instance/config/keystore.pin`
+    - You can provide your certificates in a PKCS#12 keystore with these two files:
+        `instance/config/keystore.pin`
+    - You can provide your trusted certificates in a JKS trust store by providing this file:
+        `instance/config/truststore `
+    - You can provide your trusted certificates in a JKS trust store by providing this file:
+        `instance/config/truststore.p12`
+    - Optionally, if the truststore is pin-protected, provide the
+        `instance/config/truststore.pin`
+
+### PingDataSync
+- `dsconfig`
+    Provide dsconfig configuration fragments.
+When the container starts, all the fragments are appended in the order in which they are numbered and applied in one large batch.
+Files must be named with two digits, a dash, a label, and with the .dsconfig extension
+        
+- `instance`
+    Place any file that needs to be present with the runtime of the product, in accordance with the file layout of the product.
+    - You can place custom schema in `instance/config/schema/`
+    - You can provide your certificates in a JKS keystore with these two files:
+        `instance/config/keystore`
+        `instance/config/keystore.pin`
+    - You can provide your certificates in a PKCS#12 keystore with these two files:
+        `instance/config/keystore.p12`
+        `instance/config/keystore.pin`
+    - You can provide your trusted certificates in a JKS trust store by providing this file:
+        `instance/config/truststore`
+    - You can provide your trusted certificates in a JKS trust store by providing this file:
+        `instance/config/truststore.p12`
+    - Optionally, if the truststore is pin-protected, provide the
+        `instance/config/truststore.pin`

--- a/docs/server-profiles/README.md
+++ b/docs/server-profiles/README.md
@@ -19,5 +19,5 @@ as they are often one off examples of different concepts.  Some of these product
 
 | Server Profile            | Description                                         |
 |---------------------------|-----------------------------------------------------|
-| [PingFed Cluster](https://github.com/pingidentity/server-profile-pingidentity-playground/tree/master/getting-started-pingfederate-cluster/pingfederate)           | Configuring a PingFed cluster with admin/engine nodes | 
+| [PingFed Cluster](https://github.com/pingidentity/server-profile-pingidentity-playground/tree/master/getting-started-pingfederate-cluster)           | Configuring a PingFed cluster with admin/engine nodes | 
 | [PingOne for Customer](https://github.com/pingidentity/server-profile-pingidentity-playground/tree/master/pingone-cloud) | Use cases around PingOne for Customer |

--- a/docs/server-profiles/README.md
+++ b/docs/server-profiles/README.md
@@ -1,87 +1,23 @@
 # Ping Identity Server Profiles
-This document explains how server profiles work for Ping Identity Docker images
+Ping Identity Server Profiles are used to provide the configuration, data, environment details to
+Ping Identity Docker Images.
 
-## What's in it?
-Server profiles aim at providing a common convention to adapt the common images into workable containers in all circumstances.
+## Available Server Profiles
+There are several Ping Identity Server Profiles available in the Ping Identity Github repositories.
+They are outlined in the table below.
 
-## Layout
-### PingFederate
-- `instance`
-    Place any file that need to be present with the runtime of the product, in accordance with the file layout of the product.
-    - Some examples:
-        - `instance/server/default/data/drop-in-deployer/data.zip` can be used to apply a configuration archive exported to a container.
-        This can be convenient when going from a PingFederate instance to deployed PingFederate containers
-        - `server/default/deploy/OAuthPlayground.war`
-        automatically deploy the OAuthPlayground web application
-        - `instance/server/default/conf/pingfederate.lic`
-        inject a PingFederate license into the running container
-        - `instance/server/default/conf/META-INF/hivemodule.xml`
-        apply a hivemodule configuration to the container
+| Server Profile            | Description                                         |
+|---------------------------|-----------------------------------------------------|
+| [Getting Started](https://github.com/pingidentity/server-profile-pingidentity-getting-started)           | Ping Identity products with basic install/config | 
+| [Baseline](https://github.com/pingidentity/server-profile-pingidentity-baseline)                  | Ping Identity procucts with full integration |
+| [Simple Sync](https://github.com/pingidentity/server-profile-pingidentity-simple-sync)               | DataSync server sync'ing between two Ping Directory trees |
 
-### PingAccess
-- `instance`
-    Place any file that needs to be present with the runtime of the product, in accordance  with the file layout of the product.
+## Playground Server Profiles
+There is a Github Repository containing samples, experimental, training types of server profiles that
+may be created to help with examples and getting started projects.  These are guarenteed to be documented
+as they are often one off examples of different concepts.  Some of these products include:
 
-### PingDirectory
-- `dsconfig`
-    Provide dsconfig configuration fragments.
-When the container starts, all the fragments are appended in the order in which they are numbered and applied in one large batch.
-Files must be named with two digits, a dash, a label, and with the .dsconfig extension (i.e. 12-index-oauth-grants.dsconfig).
-
-- `data`
-    Provide ldif data fragments.
-When the container starts, all the provided files are imported in the order in which they're named.
-Files must be named with two digits, a dash, the backend name (the default is userRoot), a label, and with the .ldif extension for plain LDIF or .ldif.gz for a gzip compressed file
-For example:
-    - `10-userRoot-skeleton.ldif`
-    - `20-userRoot-users.ldif.gz`
-    - `30-userRoot-groups.ldif`
-- `hooks`
-    In this directory you can put a set of custom scripts that will be called at key points during the container startup sequence.
-    - On every container start event:
-        - `00-immediate-startup.sh` is called immediately upon container startup
-    - The first time a container starts:
-        - `10-before-copying-bits.sh` is called 
-        - `20-before-setup.sh` is called immediately before the setup tool is executed
-        - `30-before-configuration.sh` is called immediately before the dsconfig tool is executed
-        - `40-before-import.sh` is called immediately before the import-ldif is executed
-    - On every container start event:
-        - `50-before-post-start.sh` is called before the built-in postStart.sh script is executed in the background
-        - `80-post-start.sh` is called instead of the built-in postStart.sh script if it is provided
-
-- `instance`
-    Place any file that needs to be present with the runtime of the product, in accordance with the file layout of the product.
-    - You can place custom schema in `instance/config/schema/`
-    - You can provide your certificates in a JKS keystore with these two files:
-        `instance/config/keystore`
-        `instance/config/keystore.pin`
-    - You can provide your certificates in a PKCS#12 keystore with these two files:
-        `instance/config/keystore.pin`
-    - You can provide your trusted certificates in a JKS trust store by providing this file:
-        `instance/config/truststore `
-    - You can provide your trusted certificates in a JKS trust store by providing this file:
-        `instance/config/truststore.p12`
-    - Optionally, if the truststore is pin-protected, provide the
-        `instance/config/truststore.pin`
-
-### PingDataSync
-- `dsconfig`
-    Provide dsconfig configuration fragments.
-When the container starts, all the fragments are appended in the order in which they are numbered and applied in one large batch.
-Files must be named with two digits, a dash, a label, and with the .dsconfig extension
-        
-- `instance`
-    Place any file that needs to be present with the runtime of the product, in accordance with the file layout of the product.
-    - You can place custom schema in `instance/config/schema/`
-    - You can provide your certificates in a JKS keystore with these two files:
-        `instance/config/keystore`
-        `instance/config/keystore.pin`
-    - You can provide your certificates in a PKCS#12 keystore with these two files:
-        `instance/config/keystore.p12`
-        `instance/config/keystore.pin`
-    - You can provide your trusted certificates in a JKS trust store by providing this file:
-        `instance/config/truststore`
-    - You can provide your trusted certificates in a JKS trust store by providing this file:
-        `instance/config/truststore.p12`
-    - Optionally, if the truststore is pin-protected, provide the
-        `instance/config/truststore.pin`
+| Server Profile            | Description                                         |
+|---------------------------|-----------------------------------------------------|
+| [PingFed Cluster](https://github.com/pingidentity/server-profile-pingidentity-playground/tree/master/getting-started-pingfederate-cluster/pingfederate)           | Configuring a PingFed cluster with admin/engine nodes | 
+| [PingOne for Customer](https://github.com/pingidentity/server-profile-pingidentity-playground/tree/master/pingone-cloud) | Use cases around PingOne for Customer |


### PR DESCRIPTION
* Moving existing main Server Profile page to an Administration page
* Changing existing main Server Profile page to a table of possible server profiles to choose from
* Modifying the SUMMARY page to link up the new pages
* Adding a build-server-profile.sh starter script (still considered beta)