### PR TITLE
GDO-286: Update compose version to 2.4

### DIFF
--- a/11-docker-compose/00-standalone/pingaccess/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingaccess/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # This server profile used as basis for ping-devop docker-launch
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/00-standalone/pingcentral/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingcentral/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # This server profile used as basis for ping-devop docker-launch
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/00-standalone/pingdirectory/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingdirectory/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # This server profile used as basis for ping-devop docker-launch
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/00-standalone/pingfederate/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingfederate/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # This server profile used as basis for ping-devop docker-launch
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/01-simple-stack/docker-compose.yaml
+++ b/11-docker-compose/01-simple-stack/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/02-replicated-pair/docker-compose.yaml
+++ b/11-docker-compose/02-replicated-pair/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 services:

--- a/11-docker-compose/03-full-stack/docker-compose.yaml
+++ b/11-docker-compose/03-full-stack/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 #--------------------------------------------------------------------------------------

--- a/11-docker-compose/04-simple-sync/docker-compose.yaml
+++ b/11-docker-compose/04-simple-sync/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 #-------------------------------------------------------------------------------------

--- a/11-docker-compose/05-pingfederate-cluster/docker-compose.yaml
+++ b/11-docker-compose/05-pingfederate-cluster/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 services:

--- a/11-docker-compose/06-pingaccess-cluster/docker-compose.yaml
+++ b/11-docker-compose/06-pingaccess-cluster/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 services:

--- a/11-docker-compose/07-pingdatagovernance/docker-compose.yaml
+++ b/11-docker-compose/07-pingdatagovernance/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: "3.1"
+version: "2.4"
 # The server profiles used in this example are intended for use with edge versions of the product image only.
 
 services:
@@ -11,7 +11,6 @@ services:
       - SERVER_PROFILE_PARENT=PDG
       - SERVER_PROFILE_PDG_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PDG_PATH=baseline/pingdatagovernance
-      - PING_IDENTITY_ACCEPT_EULA=YES
     env_file: 
       - ~/.pingidentity/devops
     #volumes:
@@ -37,7 +36,6 @@ services:
     environment: 
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=pdg-pap-integration/pingdatagovernancepap
-      - PING_IDENTITY_ACCEPT_EULA=YES
       - HTTPS_PORT=8443
     env_file: 
       - ~/.pingidentity/devops
@@ -61,7 +59,6 @@ services:
     environment:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=baseline/pingdirectory
-      - PING_IDENTITY_ACCEPT_EULA=YES
     env_file:
       - ~/.pingidentity/devops
     #volumes:

--- a/11-docker-compose/11-siem-stack/docker-compose.yaml
+++ b/11-docker-compose/11-siem-stack/docker-compose.yaml
@@ -2,20 +2,18 @@ version: "3.3"
 
 services:
   pingfederate:
-    image: pingidentity/pingfederate:edge
+    image: pingidentity/pingfederate:${PING_IDENTITY_DEVOPS_TAG}
     command: wait-for pingdirectory:389 -t 800 -- entrypoint.sh start-server
     environment:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-devops-getting-started.git
       - SERVER_PROFILE_PATH=11-docker-compose/11-siem-stack/baseline/pingfederate
-      - PING_IDENTITY_ACCEPT_EULA=YES
-      - PING_IDENTITY_DEVOPS_USER=$PING_IDENTITY_DEVOPS_USER
-      - PING_IDENTITY_DEVOPS_KEY=$PING_IDENTITY_DEVOPS_KEY
       - PF_LOG_LEVEL=DEBUG
-      
       - SOCKET_HOST=logstash
       - SOCKET_PORT_SYSTEM=20513
       - SOCKET_PORT_AUDIT=20514
       - SOCKET_PROTOCOL=TCP
+    env_file:
+      - ~/.pingidentity/devops
     ports:
       - "9031:9031"
       - "9999:9999"
@@ -28,20 +26,18 @@ services:
 #     - ./baseline/pingfederate:/opt/in
 
   pingaccess:
-    image: pingidentity/pingaccess:edge
+    image: pingidentity/pingaccess:${PING_IDENTITY_DEVOPS_TAG}
     command: wait-for pingdirectory:389 -t 800 -- entrypoint.sh start-server
     environment:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-devops-getting-started.git
       - SERVER_PROFILE_PATH=11-docker-compose/11-siem-stack/baseline/pingaccess
       - PA_LOG_LEVEL=DEBUG
-      - PING_IDENTITY_ACCEPT_EULA=YES
-      - PING_IDENTITY_DEVOPS_USER=$PING_IDENTITY_DEVOPS_USER
-      - PING_IDENTITY_DEVOPS_KEY=$PING_IDENTITY_DEVOPS_KEY
-
       - SOCKET_HOST=logstash 
       - SOCKET_PORT_SYSTEM=20516
       - SOCKET_PORT_AUDIT=20517
       - SOCKET_PROTOCOL=TCP
+    env_file:
+      - ~/.pingidentity/devops
     ports:
       - "9000:9000"
       - "3000:3000"
@@ -54,14 +50,13 @@ services:
 #     - ./baseline/pingaccess:/opt/in
 
   pingdirectory:
-    image: pingidentity/pingdirectory:latest
+    image: pingidentity/pingdirectory:${PING_IDENTITY_DEVOPS_TAG}
     environment:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-devops-getting-started.git
       - SERVER_PROFILE_PATH=11-docker-compose/11-siem-stack/baseline/pingdirectory
-      - PING_IDENTITY_ACCEPT_EULA=YES
-      - PING_IDENTITY_DEVOPS_USER=$PING_IDENTITY_DEVOPS_USER
-      - PING_IDENTITY_DEVOPS_KEY=$PING_IDENTITY_DEVOPS_KEY
       - ES_ADMIN_PD_USER_PASS=$ES_ADMIN_PD_USER_PASS
+    env_file:
+      - ~/.pingidentity/devops
     ports:
       - "1636:636"
       - "1443:443"


### PR DESCRIPTION
   - Updated to 2.4 where possible
   - Removed EULA=YES when found as it is now an env var in local config
   - Removed explict product tags to use PING_IDENTITY_DEVOPS_TAG variable
   - Removed explicit USER/KEY variables and replaced with env_file