### PR TITLE
Parameterise the MySQL database for the profile

### DIFF
--- a/11-docker-compose/30-pingcentral/docker-compose.yml
+++ b/11-docker-compose/30-pingcentral/docker-compose.yml
@@ -8,6 +8,9 @@ services:
       - SERVER_PROFILE_PATH=baseline/pingcentral/external-mysql-db
       - PING_CENTRAL_BLIND_TRUST=true
       - PING_CENTRAL_VERIFY_HOSTNAME=false
+      - MYSQL_SERVICE_HOST=pingcentral-db
+      - MYSQL_SERVICE_PORT=3306
+      - MYSQL_DATABASE=pingcentral
       - MYSQL_USER=root
       - MYSQL_PASSWORD=2Federate
     env_file:


### PR DESCRIPTION
The server profile was changed to include MySQL database params (hostname, port, database name).  Changing the example to reflect the new environment variables