### PR TITLE
GDO-380: PingAccess Clustering (Admin Console) not working in Kubernetes

### DIFF
--- a/20-kubernetes/04-clustered-pingaccess/env_vars.pingaccess-admin
+++ b/20-kubernetes/04-clustered-pingaccess/env_vars.pingaccess-admin
@@ -1,5 +1,8 @@
 SERVER_PROFILE_URL=https://www.github.com/pingidentity/pingidentity-server-profiles.git
 SERVER_PROFILE_PATH=pa-clustering/pingaccess
+SERVER_PROFILE_PARENT=ADMIN
+SERVER_PROFILE_ADMIN_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
+SERVER_PROFILE_ADMIN_PATH=pa-clustering/pingaccess-admin
 PING_IDENTITY_ACCEPT_EULA=YES
 OPERATIONAL_MODE=CLUSTERED_CONSOLE
 PA_CONSOLE_HOST=pingaccess-admin


### PR DESCRIPTION
  - Resoloved issue by layering additional admin profile used in compose example
  - Tested fix in AWS K8s cluster