### PR TITLE
add sensible resources to init containers

### DIFF
--- a/20-kubernetes/02-fullstack/wait-for-directory.yaml
+++ b/20-kubernetes/02-fullstack/wait-for-directory.yaml
@@ -9,3 +9,10 @@ spec:
         - name: init
           image: curlimages/curl:latest
           command: ['sh', '-c', 'until curl --connect-timeout 1 --silent -k https://pingdirectory:443/directory/v1 ; do echo waiting for admin ; sleep 2 ; done']
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/20-kubernetes/02-fullstack/wait-for-federate.yaml
+++ b/20-kubernetes/02-fullstack/wait-for-federate.yaml
@@ -9,3 +9,10 @@ spec:
         - name: init
           image: curlimages/curl:latest
           command: ['sh', '-c', 'until curl --connect-timeout 1 --silent -k https://pingfederate:9999/pingfederate/app ; do echo waiting for admin ; sleep 2 ; done']
+          resources:
+            limits:
+              cpu: 50m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 128Mi

--- a/20-kubernetes/04-clustered-pingaccess/pingaccess-engine.yaml
+++ b/20-kubernetes/04-clustered-pingaccess/pingaccess-engine.yaml
@@ -37,6 +37,13 @@ spec:
       - name: init
         image: curlimages/curl:latest
         command: ['sh', '-c', 'until curl --connect-timeout 1 --silent -k https://pingaccess-admin:9000 ; do echo waiting for admin ; sleep 3 ; done']
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
       containers:
       - name: pingaccess
         image: pingidentity/pingaccess:edge

--- a/20-kubernetes/06-clustered-pingfederate/pingfederate-engine.yaml
+++ b/20-kubernetes/06-clustered-pingfederate/pingfederate-engine.yaml
@@ -89,3 +89,10 @@ spec:
       - name: init
         image: curlimages/curl:latest
         command: ['sh', '-c', 'until curl --connect-timeout 1 --silent -k https://pingfederate-admin:9999/pingfederate/app ; do echo waiting for admin ; sleep 2 ; done']
+        resources:
+          limits:
+            cpu: 50m
+            memory: 128Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi


### PR DESCRIPTION
The [init container is currently taking on the resource request of the ping containers](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources); which is relatively high.  In production this will most likely trigger a worker node autoscale up. 

https://kubernetes.io/docs/concepts/workloads/pods/init-containers/#resources

I understand that these are just examples so take it or leave it; just sharing back.


