### PR TITLE
Provide better support of k8s dns srv records

### DIFF
--- a/20-kubernetes/01-standalone/pingdirectory/pingdirectory.yaml
+++ b/20-kubernetes/01-standalone/pingdirectory/pingdirectory.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: ldaps
     port: 636
-  - name: ssl
+  - name: https
     port: 443
   - name: ldap
     port: 389

--- a/20-kubernetes/12-pingdirectory-upgrade/1-inital.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/1-inital.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: ldaps
     port: 1636
-  - name: ssl
+  - name: https
     port: 1443
   - name: ldap
     port: 1389

--- a/20-kubernetes/12-pingdirectory-upgrade/2-partition.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/2-partition.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: ldaps
     port: 1636
-  - name: ssl
+  - name: https
     port: 1443
   - name: ldap
     port: 1389

--- a/20-kubernetes/12-pingdirectory-upgrade/3-staging.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/3-staging.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: ldaps
     port: 1636
-  - name: ssl
+  - name: https
     port: 1443
   - name: ldap
     port: 1389

--- a/20-kubernetes/12-pingdirectory-upgrade/4-rollout.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/4-rollout.yaml
@@ -27,7 +27,7 @@ spec:
   ports:
   - name: ldaps
     port: 1636
-  - name: ssl
+  - name: https
     port: 1443
   - name: ldap
     port: 1389


### PR DESCRIPTION
This is a little pedantic, but will result in funky behavior from some tools that rely on proper DNS SRV searches.

https://kubernetes.io/docs/concepts/services-networking/service/#dns

