### PR TITLE
closes GDO-642

### DIFF
--- a/docs/get-started/getStartedWithGitRepo.md
+++ b/docs/get-started/getStartedWithGitRepo.md
@@ -57,11 +57,11 @@ You'll use Git to clone the `pingidentity-devops-getting-started` repository, an
 
     | Product | Connection Details |
     | --- | --- |
-    | [PingFederate](https://localhost:9999/pingfederate/app) | <ul> <li>URL: [https://localhost:9999/pingfederate/app](https://localhost:9999/pingfederate/app)</li><li>Username: administrator</li><li>Password: 2FederateMore</li></ul> |
-    | [PingDirectory](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdirectory:636</li><li>Username: administrator</li><li>Password: 2FederateMore</li></ul> |
-    | [PingAccess](https://localhost:9000) | <ul><li>URL: [https://localhost:9000](https://localhost:9000)</li><li>Username: administrator</li><li>Password: 2FederateMore</li></ul> |
-    | [PingDataGovernance](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdatagovernance:636</li><li>Username: administrator</li><li>Password: 2FederateMore</li></ul> |
-    | [PingDataSync](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdatasync:636</li><li>Username: administrator</li><li>Password: 2FederateMore</li></ul> |
+    | [PingFederate](https://localhost:9999/pingfederate/app) | <ul> <li>URL: [https://localhost:9999/pingfederate/app](https://localhost:9999/pingfederate/app)</li><li>Username: administrator</li><li>Password: 2FederateM0re</li></ul> |
+    | [PingDirectory](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdirectory:636</li><li>Username: administrator</li><li>Password: 2FederateM0re</li></ul> |
+    | [PingAccess](https://localhost:9000) | <ul><li>URL: [https://localhost:9000](https://localhost:9000)</li><li>Username: administrator</li><li>Password: 2FederateM0re</li></ul> |
+    | [PingDataGovernance](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdatagovernance:636</li><li>Username: administrator</li><li>Password: 2FederateM0re</li></ul> |
+    | [PingDataSync](https://localhost:8443/console) | <ul><li>URL: [https://localhost:8443/console](https://localhost:8443/console)</li><li>Server: pingdatasync:636</li><li>Username: administrator</li><li>Password: 2FederateM0re</li></ul> |
     | [PingCentral](https://localhost:9022) | <ul><li>URL: [https://localhost:9022](https://localhost:9022)</li><li>Username: administrator</li><li>Password: 2Federate</li></ul> |
     | Apache Directory Studio for PingDirectory |<ul> <li>LDAP Port: 1636</li><li>LDAP BaseDN: dc=example,dc=com</li><li>Root Username: cn=administrator</li><li>Root Password: 2FederateM0re</li></ul> |
 

--- a/docs/get-started/prodLicense.md
+++ b/docs/get-started/prodLicense.md
@@ -7,7 +7,11 @@ In order to run the Ping Identity DevOps images, a valid product license is requ
 By registering for Ping Identity's DevOps program, you'll be issued credentials that will automate the process of retrieving evaluation product license.
 
 !!! warning "Evaluation License"
-    Please note that evaluation licenses are short lived (30 days) and should **not** be used in production deployments.
+    Please note that evaluation licenses are short lived (30 days) and **must not** be used in production deployments.
+
+Evaluation licenses can only be used with images published in the last 90 days.
+If you wish to continue to use an image that was published more than 90 days ago, you must obtain a product license.
+Once you have product license for the product and version of the more-than-90-days-old image, follow the instructions to [mount the product license](#mount-existing-product-license).
 
 * [Using your DevOps User/Key](#using-your-devops-user-and-key)
 

--- a/docs/reference/imageSupport.md
+++ b/docs/reference/imageSupport.md
@@ -34,16 +34,16 @@ Examples:
 
 | Product               | Actively Maintained Image |
 | --- | --- |
-| PingAccess            | <ul><li>6.1</li><li>6.0</li></ul> |
-| PingCentral           | <ul><li>1.5</li><li>1.4</li></ul> |
-| PingDataConsole       | <ul><li>8.1</li><li>8.0</li></ul> |
-| PingDataGovernance    | <ul><li>8.1</li><li>8.0</li></ul> |
-| PingDataGovernancePAP | <ul><li>8.1</li><li>8.0</li></ul> |
-| PingDataSync          | <ul><li>8.1</li><li>8.0</li></ul> |
+| PingAccess            | <ul><li>6.2</li><li>6.1</li></ul> |
+| PingCentral           | <ul><li>1.6</li><li>1.5</li></ul> |
+| PingDataConsole       | <ul><li>8.2</li><li>8.1</li></ul> |
+| PingDataGovernance    | <ul><li>8.2</li><li>8.1</li></ul> |
+| PingDataGovernancePAP | <ul><li>8.2</li><li>8.1</li></ul> |
+| PingDataSync          | <ul><li>8.2</li><li>8.1</li></ul> |
 | PingDelegator         | <ul><li>4.4.0</li></ul> |
-| PingDirectory         | <ul><li>8.1</li><li>8.0</li></ul> |
-| PingDirectoryProxy    | <ul><li>8.1</li><li>8.0</li></ul> |
-| PingFederate          | <ul><li>10.0</li><li>10.1</li></ul> |
-| PingIntelligence      | <ul><li>4.3</li></ul> |
+| PingDirectory         | <ul><li>8.2</li><li>8.1</li></ul> |
+| PingDirectoryProxy    | <ul><li>8.2</li><li>8.1</li></ul> |
+| PingFederate          | <ul><li>10.2</li><li>10.1</li></ul> |
+| PingIntelligence      | <ul><li>4.4</li></ul> |
 
 !!! info "Last Update  Dec 15, 2020"


### PR DESCRIPTION
this updates the documentation with a clearer description of the evaluation license error message some customers are reaching out to the devops_program alias about.
It also updates the support matrix following the slew of product releases in late December. Finally, there was a discrepancy in the documented passwords