### PR TITLE
BRASS-181: K8s examples on Github have issues with liveness/readiness…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/20-kubernetes/01-standalone/pingdirectory/pingdirectory.yaml
+++ b/20-kubernetes/01-standalone/pingdirectory/pingdirectory.yaml
@@ -77,6 +77,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -87,7 +89,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "2"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/01-single-namespace/01-west.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/01-single-namespace/01-west.yaml
@@ -161,6 +161,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -171,7 +173,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/01-single-namespace/02-east.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/01-single-namespace/02-east.yaml
@@ -161,6 +161,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -171,7 +173,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/02-single-cluster-two-namespaces/01-west.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/02-single-cluster-two-namespaces/01-west.yaml
@@ -157,6 +157,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -167,7 +169,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/02-single-cluster-two-namespaces/02-east.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/02-single-cluster-two-namespaces/02-east.yaml
@@ -157,6 +157,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -167,7 +169,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/03-multi-cluster-dns/01-west.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/03-multi-cluster-dns/01-west.yaml
@@ -176,6 +176,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 300
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 7636
@@ -186,7 +188,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/09-multi-k8s-pingdirectory/03-multi-cluster-dns/02-east.yaml
+++ b/20-kubernetes/09-multi-k8s-pingdirectory/03-multi-cluster-dns/02-east.yaml
@@ -189,7 +189,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         resources:
           limits:
             cpu: "6"

--- a/20-kubernetes/12-pingdirectory-upgrade/1-inital.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/1-inital.yaml
@@ -77,6 +77,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 500
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -87,7 +89,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /opt/out
           name: out-dir

--- a/20-kubernetes/12-pingdirectory-upgrade/2-partition.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/2-partition.yaml
@@ -80,6 +80,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 500
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -90,7 +92,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /opt/out
           name: out-dir

--- a/20-kubernetes/12-pingdirectory-upgrade/3-staging.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/3-staging.yaml
@@ -81,6 +81,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 500
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -91,7 +93,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /opt/out
           name: out-dir

--- a/20-kubernetes/12-pingdirectory-upgrade/4-rollout.yaml
+++ b/20-kubernetes/12-pingdirectory-upgrade/4-rollout.yaml
@@ -80,6 +80,8 @@ spec:
             - /opt/liveness.sh
           initialDelaySeconds: 500
           periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
         name: pingdirectory
         ports:
         - containerPort: 1636
@@ -90,7 +92,9 @@ spec:
             command:
             - /bin/sh
             - -c
-            - /opt/liveness.sh
+            - /opt/readiness.sh
+          timeoutSeconds: 5
+          failureThreshold: 3
         volumeMounts:
         - mountPath: /opt/out
           name: out-dir


### PR DESCRIPTION
… probes

- Update all PingDirectory liveness and readiness probes to use
timeoutSeconds 5 and failureThreshold 3.
- Update all PingDirectory readiness probes to use readiness.sh.