### PR TITLE
Add PING_ENABLE_API_HTTP_CACHE env var doc

### DIFF
--- a/docs/docker-images/pingauthorizepap/README.md
+++ b/docs/docker-images/pingauthorizepap/README.md
@@ -36,7 +36,7 @@ this image.
 | TAIL_LOG_FILES  | ${SERVER_ROOT_DIR}/logs/pingauthorize-pap.log ${SERVER_ROOT_DIR}/logs/setup.log ${SERVER_ROOT_DIR}/logs/start-server.log ${SERVER_ROOT_DIR}/logs/stop-server.log  | Files tailed once container has started  |
 | REST_API_HOSTNAME  | localhost  | Hostname used for the REST API (deprecated, use `PING_EXTERNAL_BASE_URL` instead)  |
 | DECISION_POINT_SHARED_SECRET  | 2FederateM0re  | Define shared secret between PAZ and the Policy Editor  |
-| PING_ENABLE_API_HTTP_CACHE | true | When set to `false`, disables default HTTP API caching in the Policy Manager, Trust Framework, and Test Suite. |
+| PING_ENABLE_API_HTTP_CACHE | true | When set to `false`, disables default HTTP API caching in the Policy Manager, Trust Framework, and Test Suite |
 
 ## Ports Exposed
 

--- a/docs/docker-images/pingauthorizepap/README.md
+++ b/docs/docker-images/pingauthorizepap/README.md
@@ -36,6 +36,7 @@ this image.
 | TAIL_LOG_FILES  | ${SERVER_ROOT_DIR}/logs/pingauthorize-pap.log ${SERVER_ROOT_DIR}/logs/setup.log ${SERVER_ROOT_DIR}/logs/start-server.log ${SERVER_ROOT_DIR}/logs/stop-server.log  | Files tailed once container has started  |
 | REST_API_HOSTNAME  | localhost  | Hostname used for the REST API (deprecated, use `PING_EXTERNAL_BASE_URL` instead)  |
 | DECISION_POINT_SHARED_SECRET  | 2FederateM0re  | Define shared secret between PAZ and the Policy Editor  |
+| PING_ENABLE_API_HTTP_CACHE | true | Controls the API HTTP cache feature. Use `false` to disable |
 
 ## Ports Exposed
 

--- a/docs/docker-images/pingauthorizepap/README.md
+++ b/docs/docker-images/pingauthorizepap/README.md
@@ -36,7 +36,7 @@ this image.
 | TAIL_LOG_FILES  | ${SERVER_ROOT_DIR}/logs/pingauthorize-pap.log ${SERVER_ROOT_DIR}/logs/setup.log ${SERVER_ROOT_DIR}/logs/start-server.log ${SERVER_ROOT_DIR}/logs/stop-server.log  | Files tailed once container has started  |
 | REST_API_HOSTNAME  | localhost  | Hostname used for the REST API (deprecated, use `PING_EXTERNAL_BASE_URL` instead)  |
 | DECISION_POINT_SHARED_SECRET  | 2FederateM0re  | Define shared secret between PAZ and the Policy Editor  |
-| PING_ENABLE_API_HTTP_CACHE | true | Controls the API HTTP cache feature. Use `false` to disable |
+| PING_ENABLE_API_HTTP_CACHE | true | When set to `false`, disables default HTTP API caching in the Policy Manager, Trust Framework, and Test Suite. |
 
 ## Ports Exposed
 


### PR DESCRIPTION
This is in DRAFT until the actual 9.1-EA release occurs and the environment variable becomes available.

To view content (from corporate intranet): https://mkdocs.ping-eng.com/docker-images/pingauthorizepap/

Commit message:

```
This documents the PING_ENABLE_API_HTTP_CACHE environment variable. The
variable controls the API HTTP caching functionality introduced in the
initial 9.1 EA release of the PingAuthorize Policy Editor. By default,
the cache is enabled. In order to disable it, customers must provide the
environment variable PING_ENABLE_API_HTTP_CACHE=false.

JiraIssue: PAZ-3949
```