### PR TITLE
BRASS-406: Update Getting Started Examples to Pingctl Standards

### DIFF
--- a/11-docker-compose/00-standalone/pingaccess/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingaccess/docker-compose.yaml
@@ -25,7 +25,7 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=getting-started/pingaccess
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ports:
       - "3000:3000"
       - "9000:9000"

--- a/11-docker-compose/00-standalone/pingcentral/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingcentral/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
   pingcentral:
     image: ${PING_IDENTITY_DEVOPS_REGISTRY:-docker.io/pingidentity}/pingcentral:${PING_IDENTITY_DEVOPS_TAG:-edge}
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ports:
       - "9022:9022"
     networks:

--- a/11-docker-compose/00-standalone/pingdirectory/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingdirectory/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=getting-started/pingdirectory
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     networks:
       - pingnet
     ulimits:

--- a/11-docker-compose/00-standalone/pingfederate/docker-compose.yaml
+++ b/11-docker-compose/00-standalone/pingfederate/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - PF_LDAP_USERNAME="Administrator"
       - PF_LDAP_PASSWORD="2FederateM0re"
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ports:
       - "9031:9031"
       - "9999:9999"

--- a/11-docker-compose/04-simple-sync/docker-compose.yaml
+++ b/11-docker-compose/04-simple-sync/docker-compose.yaml
@@ -36,7 +36,7 @@ services:
       - SERVER_PROFILE_PATH=simple-sync/pingdirectory
       - USER_BASE_DN=o=sync
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -62,7 +62,7 @@ services:
       - SERVER_PROFILE_PATH=simple-sync/pingdatasync
       - USER_BASE_DN=o=sync
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384

--- a/11-docker-compose/07-pingauthorize/docker-compose.yaml
+++ b/11-docker-compose/07-pingauthorize/docker-compose.yaml
@@ -12,7 +12,7 @@ services:
       - SERVER_PROFILE_PAZ_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PAZ_PATH=baseline/pingauthorize
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -38,7 +38,7 @@ services:
       - SERVER_PROFILE_PATH=paz-pap-integration/pingauthorizepap
       - HTTPS_PORT=8443
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -60,7 +60,7 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=baseline/pingdirectory
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384

--- a/11-docker-compose/07-pingdatagovernance/docker-compose.yaml
+++ b/11-docker-compose/07-pingdatagovernance/docker-compose.yaml
@@ -14,7 +14,7 @@ services:
       - SERVER_PROFILE_PDG_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PDG_PATH=baseline/pingdatagovernance
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -42,7 +42,7 @@ services:
       - SERVER_PROFILE_PATH=pdg-pap-integration/pingdatagovernancepap
       - HTTPS_PORT=8443
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -66,7 +66,7 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=baseline/pingdirectory
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384

--- a/11-docker-compose/12-sync-failover-pair/docker-compose.yaml
+++ b/11-docker-compose/12-sync-failover-pair/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       - SERVER_PROFILE_PATH=simple-sync/pingdirectory
       - USER_BASE_DN=o=sync
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384
@@ -69,7 +69,7 @@ services:
       - COMPOSE_SERVICE_NAME=12-sync-failover-pair_pingdatasync
       - PING_IDENTITY_PASSWORD=2FederateM0re
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ulimits:
       nproc:
         soft: 16384

--- a/11-docker-compose/13-pingdataconsole-pingone-sso/docker-compose.yaml
+++ b/11-docker-compose/13-pingdataconsole-pingone-sso/docker-compose.yaml
@@ -43,7 +43,7 @@ services:
       - SERVER_PROFILE_PATH=pingdataconsole-sso/pingdirectory
       - PD_CONSOLE_SSO_ISSUER_URI=https://example.com
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     networks:
       - pingnet
     ulimits:

--- a/11-docker-compose/30-pingcentral/docker-compose.yml
+++ b/11-docker-compose/30-pingcentral/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - MYSQL_USER=root
       - MYSQL_PASSWORD=2Federate
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ports:
       - "9022:9022"
     depends_on:

--- a/11-docker-compose/30-pingcentral/embedded-h2.yaml
+++ b/11-docker-compose/30-pingcentral/embedded-h2.yaml
@@ -9,6 +9,6 @@ services:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=baseline/pingcentral/logging
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     ports:
       - "9022:9022"

--- a/docs/docker-images/pingcentral/README.md
+++ b/docs/docker-images/pingcentral/README.md
@@ -49,7 +49,7 @@ used, then it may come from a parent container
 To run a PingCentral container with your devops configuration file:
 ```shell docker run -Pt \
            --name pingcentral \
-           --env-file ~/.pingidentity/devops \
+           --env-file ~/.pingidentity/config \
            --env PING_IDENTITY_ACCEPT_EULA=YES \
            --env PING_IDENTITY_DEVOPS_USER \
            --env PING_IDENTITY_DEVOPS_KEY \
@@ -62,7 +62,7 @@ or with long options in the background:
            --name pingcentral \
            --publish 9022:9022 \
            --detach \
-           --env-file ~/.pingidentity/devops \
+           --env-file ~/.pingidentity/config \
            --env PING_IDENTITY_ACCEPT_EULA=YES \
            --env PING_IDENTITY_DEVOPS_USER \
            --env PING_IDENTITY_DEVOPS_KEY \

--- a/docs/get-started/devopsUserKey.md
+++ b/docs/get-started/devopsUserKey.md
@@ -73,7 +73,7 @@ Add the `env_file` configuration option to the YAML file for the stack. The `env
   pingdirectory:
     image: pingidentity/pingdirectory
     env_file:
-    - ${HOME}/.pingidentity/devops
+    - ${HOME}/.pingidentity/config
     environment:
     - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
     - SERVER_PROFILE_PATH=getting-started/pingdirectory

--- a/docs/get-started/prodLicense.md
+++ b/docs/get-started/prodLicense.md
@@ -55,7 +55,7 @@ The following example shows running a Docker image using any Docker .yaml file.
   pingdirectory:
     image: pingidentity/pingdirectory
     env_file:
-      - ${HOME}/.pingidentity/devops
+      - ${HOME}/.pingidentity/config
     environment:
       - SERVER_PROFILE_URL=https://github.com/pingidentity/pingidentity-server-profiles.git
       - SERVER_PROFILE_PATH=getting-started/pingdirectory

--- a/docs/ping-devops/topics/troubleshooting-docker
+++ b/docs/ping-devops/topics/troubleshooting-docker
@@ -7,7 +7,7 @@ test your ~/.pingidentity/config file has been setup correctly.
 
 The output should look something like this:
 
-    > docker run --env-file ${HOME}/.pingidentity/devops alpine env | sort
+    > docker run --env-file ${HOME}/.pingidentity/config alpine env | sort
     HOME=/root
     HOSTNAME=cc4008ce6105
     PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
@@ -20,7 +20,7 @@ The output should look something like this:
 
 If the PING_IDENTITY_... variables are missing, then either:
 
- 1. Your ${HOME}/.pingidentity/devops folder hasn't been configured correctly.  
+ 1. Your ${HOME}/.pingidentity/config folder hasn't been configured correctly.
     You can fix this with:
 
       ping-devops config
@@ -29,7 +29,7 @@ If the PING_IDENTITY_... variables are missing, then either:
     sourced correctly.  Ensure that your .bash_profile (bash) or .zshrc (zsh)
     are sourcing:
 
-      ${HOME}/.pingidentity/devops
+      ${HOME}/.pingidentity/config
 
     In some linux distros (i.e. Ubuntu), you may also need to set allexports 
     by adding


### PR DESCRIPTION
- Remove missed additional references to `${HOME}/.pingidentity/devops`
with `${HOME}/.pingidentity/config` to match pingctl.