### PR TITLE
Proposal to split pingaccess-cluster.yaml in two different yamls (1/2)

### DIFF
--- a/30-helm/pingaccess-federate-integration.yaml
+++ b/30-helm/pingaccess-federate-integration.yaml
@@ -1,0 +1,59 @@
+global:
+  envs:
+    PING_IDENTITY_ACCEPT_EULA: "YES"
+    PING_IDENTITY_PASSWORD: "2Federate"
+
+#############################################################
+# pingaccess-admin values
+#############################################################
+pingaccess-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingaccess
+  container:
+    waitFor:
+      pingfederate-admin:
+        service: https
+        timeoutSeconds: 300
+  privateCert:
+    generate: true
+
+#############################################################
+# pingaccess-engine values
+#############################################################
+pingaccess-engine:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingaccess
+  container:
+    waitFor:
+      pingfederate-admin:
+        service: https
+        timeoutSeconds: 300
+
+#############################################################
+# pingfederate-admin values
+#############################################################
+pingfederate-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
+  clustering:
+    autoscaling:
+      enabled: false
+  container:
+    replicaCount: 1
+
+#############################################################
+# pingfederate-engine values
+#############################################################
+pingfederate-engine:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
+  container:
+    replicaCount: 1


### PR DESCRIPTION
I believe what the current pingaccess-cluster.yaml is trying to accomplish is not working well and should be split in two different features.
1. One yaml to deploy PingAccess and PingFederate, building the integration between those two.
Currently the pingaccess-cluster.yaml is getting the files from baseline/pingaccess which already contains a few configurations to integrate with PingFederate, however the block referencing PingFederate is getting the files from getting-started/pingfederate which does not have the configuration to do such integration (for example, the configuration from baseline/pingaccess is expecting PingFederate to have a client named rs_client which is deployed with the OAuthPlayground.war package and it does not exist in getting-started/pingfederate).