### PR TITLE
Proposal to split pingaccess-cluster.yaml in two different yamls (2/2)

### DIFF
--- a/30-helm/pingaccess-cluster.yaml
+++ b/30-helm/pingaccess-cluster.yaml
@@ -2,14 +2,6 @@ global:
   envs:
     PING_IDENTITY_ACCEPT_EULA: "YES"
     PING_IDENTITY_PASSWORD: "2Federate"
-  ingress:
-    enabled: true
-    addReleaseNameToHost: prepend
-    defaultDomain: "insert domain name here"
-    defaultTlsSecret:
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      kubernetes.io/ingress.class: "nginx-public"
 
 #############################################################
 # pingaccess-admin values
@@ -18,35 +10,7 @@ pingaccess-admin:
   enabled: true
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: baseline/pingaccess
-  container:
-    resources:
-      requests:
-        cpu: 0
-        memory: 1.5Gi
-      limits:
-        cpu: 2
-        memory: 4Gi
-    waitFor:
-      pingfederate-admin:
-        service: https
-        timeoutSeconds: 300
-  privateCert:
-    generate: true
-
-  # Example: If PingAccess Admin relies on pingfederate-admin for AuthN
-  #          Creates init container wait-for on pingfederate-admin https service
-
-  services:
-    https:
-      servicePort: 9000
-      containerPort: 9000
-      ingressPort: 443
-      dataService: true
-    clusterconfig:
-      servicePort: 9090
-      containerPort: 9090
-      dataService: true
+    SERVER_PROFILE_PATH: getting-started/pingaccess
 
 #############################################################
 # pingaccess-engine values
@@ -55,41 +19,4 @@ pingaccess-engine:
   enabled: true
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: baseline/pingaccess
-  container:
-    resources:
-      requests:
-        cpu: 0
-        memory: 1Gi
-      limits:
-        cpu: 2
-        memory: 4Gi
-    waitFor:
-      pingaccess-admin:
-        service: https
-        timeoutSeconds: 300
-  services:
-    https:
-      servicePort: 3000
-      containerPort: 3000
-      ingressPort: 443
-      dataService: true
-
-pingfederate-admin:
-  enabled: true
-  container:
-    replicaCount: 1
-  envs:
-    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: getting-started/pingfederate
-
-pingfederate-engine:
-  enabled: true
-  envs:
-    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: getting-started/pingfederate
-  clustering:
-    autoscaling:
-      enabled: false
-  container:
-    replicaCount: 1
+    SERVER_PROFILE_PATH: getting-started/pingaccess


### PR DESCRIPTION
(Continuing from #380 )
2. The last one is to have the pingaccess-cluster.yaml referencing the getting-started/pingaccess repository, so we can deploy it with no requirements (vanilla) and independent from PingFederate. It's also better for organization, having pingfederate-cluster.yaml, pingaccess-cluster.yaml and pingaccess-federate-integration.yaml independent from each other.