### PR TITLE
increase visibility & clarification around tagging process

### DIFF
--- a/docs/docker-images/dockerImagesRef.md
+++ b/docs/docker-images/dockerImagesRef.md
@@ -14,3 +14,5 @@ These documents for Ping Identity Docker images include information on:
 The image-specific documentation is generated from each new build ensuring these documents align with any changes over time.
 
 Older images based on product versions that are no longer supported under our policy are removed from Docker Hub.  See the [support policy page](./imageSupport.md) for details.
+
+As with many organizations, Ping Identity uses _floating_ Docker image tags. This practice means, for example, that the **`edge`** tag does not refer to the same image over time as product updates occur. The [release tags](./releaseTags.md) page has information on the `edge` and other tags, how often they are updated, and how to ensure the use of a particular version and release of a product image.

--- a/docs/docker-images/imageSupport.md
+++ b/docs/docker-images/imageSupport.md
@@ -38,7 +38,7 @@ Examples:
 
 ## Docker Hub image removal
 
-Security vulnerabilities that arise over time and the continued evolution of our products creates a situation in which older product images should be replaced with newer ones in your environment.  Images that have fallen out of Ping's active maintenance window **are removed from Docker Hub 1 year after they were last built**. If you need to keep images longer than this period, you will need to store them in a private repository.  The [Docker documentation](https://docs.docker.com/engine/reference/commandline/tag/) has instructions on this process.
+Security vulnerabilities that arise over time and the continued evolution of our products create a situation in which older product images should be replaced with newer ones in your environment.  Images that have fallen out of Ping's active maintenance window **are removed from Docker Hub 1 year after they were last built**. If you need to keep images longer than this period, you will need to store them in a private repository.  The [Docker documentation](https://docs.docker.com/engine/reference/commandline/tag/) has instructions on this process.
 
 ## Supported OS shim
 

--- a/docs/docker-images/releaseTags.md
+++ b/docs/docker-images/releaseTags.md
@@ -11,9 +11,9 @@ Ping Identity uses multiple tags for each released image. On our [Docker Hub](ht
 
 ## Store images privately
 
-Before discussing tags, it is important to know more about Ping Identity's use of Docker Hub for images.  While Docker Hub is very reliable and you can always find the latest images of Ping Identity products hosted there, **do not** rely on Ping to maintain Docker images in Docker Hub over time. See the [image support policy](./imageSupport.md) for details. 
+Before discussing tags, it is important to know more about Ping Identity's use of Docker Hub for images.  While Docker Hub is very reliable and you can always find the latest images of Ping Identity products hosted there, **do not** rely on Ping to maintain Docker images in Docker Hub over time. See the [image support policy](./imageSupport.md) for details.
 
-To ensure continued access to any image you need, pull the image in question and maintain it in your own image registry. Common Docker registry providers include: JFrog, AWS ECR, Google GCR and Azure ACR.
+To ensure continued access to any image, pull the image in question and maintain it in your own image registry. Common Docker registry providers include: JFrog, AWS ECR, Google GCR and Azure ACR.
 
 ## Tagging Format
 
@@ -46,7 +46,7 @@ For customers in production environments, stability is often the highest priorit
 
 ### Latest Image Features
 
-For demonstrations and testing latest features, use an `edge` based image. In these situations, it is a good practice to use a **_full tag_** variation similar to `pingfederate:11.1.0-edge`, rather than simply `pingfederate:edge`. Doing so avoids dependency conflicts that might occur in server profiles between product versions.
+For demonstrations and testing latest features, use an `edge` based image. In these situations, it is a good practice to use a **_full tag_** variation similar to `pingfederate:11.1.0-edge`, rather than simply `pingfederate:edge`. Doing so avoids dependency conflicts that might occur in server profiles between product versions (for example, 10.x versus 11.x).
 
 ### Evergreen Bleeding Edge
 

--- a/docs/docker-images/releaseTags.md
+++ b/docs/docker-images/releaseTags.md
@@ -1,56 +1,61 @@
 ---
 title:  Using Release Tags
 ---
+
 # Using Release Tags
 
-Ping Identity uses multiple tags for each released build image. On our [Docker Hub](https://hub.docker.com/u/pingidentity) site, you can view the available tags for each image.
+Ping Identity uses multiple tags for each released image. On our [Docker Hub](https://hub.docker.com/u/pingidentity) site, you can view the available tags for each image.
 
 !!! info "Multi-product deployment"
     All product containers in a deployment should use the same release tag.
 
+## Store images privately
+
+Before discussing tags, it is important to know more about Ping Identity's use of Docker Hub for images.  While Docker Hub is very reliable and you can always find the latest images of Ping Identity products hosted there, **do not** rely on Ping to maintain Docker images in Docker Hub over time. See the [image support policy](./imageSupport.md) for details. 
+
+To ensure continued access to any image you need, pull the image in question and maintain it in your own image registry. Common Docker registry providers include: JFrog, AWS ECR, Google GCR and Azure ACR.
+
 ## Tagging Format
 
-To specify a release tag for stacks, use the follow format:
+To specify a release tag for deployments, use the following format:
 
 ```yaml
 image: pingidentity/<ping-product>:${PING_IDENTITY_DEVOPS_TAG}
 ```
 
-Where `<ping-product>` is the name of the product container and `${PING_IDENTITY_DEVOPS_TAG}` is assigned the release tag value. The reference to the file containing the setting for `${PING_IDENTITY_DEVOPS_TAG}` is `~/.pingidentity/config` by default. You can also specify the release tag explicitly in the YAML file. The release tag must be the same for each container in the stack. For example:
+In the example above, `<ping-product>` is the name of the product and `${PING_IDENTITY_DEVOPS_TAG}` is the assigned release tag value. The file containing the setting for `${PING_IDENTITY_DEVOPS_TAG}` is `~/.pingidentity/config` by default. This file is created by running the `pinctl config` command, documented [here](../tools/pingctlUtil.md). You can also specify the release tag explicitly in your deployments. The release tag must be the same for each container in the deployment. For example:
 
 ```yaml
 image: pingidentity/<ping-product>:edge
 ```
 
-## Which Release Tag To Use
+## Determine Which Tag To Use
 
-Which tag you should use depends on what you want to accomplish.
+The tag to use depends on the purpose of the deployment in question.  Along with using a tag, any image on Docker Hub can be referenced using the [SHA256 digest](https://docs.docker.com/engine/reference/commandline/images/#list-image-digests) to ensure immutability in your environments.  The digest for a given image never changes regardless of any tag or tags with which it is associated.
 
 ### Production Stability
 
-For customers in production environments, stability is often the most sought after quality. For the least dependencies and the most stability:
+For customers in production environments, stability is often the highest priority. To ensure a deployment with the fewest dependencies and highest product stability:
 
-* Use the [digest](https://docs.docker.com/engine/reference/commandline/images/#list-image-digests) of a _full sprint tag_ that includes the [sprint](#sprint) version and product version.
-    * For example: `pingidentity/pingfederate:2103-10.2.2`. To pull its corresponding digest:
+* Use the digest of a _full sprint tag_ that includes the [sprint](#sprint) version and product version.  For example, consider the image tag `pingidentity/pingfederate:2206-11.1.0`. To pull this image using the corresponding digest:
 
-        ```sh
-        docker pull pingidentity/pingfederate@sha256:cef3a089e941c837aa598739f385722157eae64510108e81b2064953df2e9537
-        ```
+    ```sh
+    docker pull pingidentity/pingfederate@sha256:8eb88fc3345d8d71dafd83bcdcc38827ddb09768c6571c930b4d217ea177debf
+    ```
 
-    * Additionally, **do not** rely on Ping to maintain Docker images on Docker Hub. Instead pull the image of choice and maintain it in your own image registry. Common providers include: JFrog, AWS ECR, Google GCR, Azure ACR.
 
 ### Latest Image Features
 
-For demonstrations and testing latest features, use an `edge` based image. Even for demos and testing, it's a good practice to use a _full tag_ variation like `pingfederate:10.2.2-edge`, rather than `pingfederate:edge`, to avoid dependency conflicts in server profiles.
+For demonstrations and testing latest features, use an `edge` based image. In these situations, it is a good practice to use a **_full tag_** variation similar to `pingfederate:11.1.0-edge`, rather than simply `pingfederate:edge`. Doing so avoids dependency conflicts that might occur in server profiles between product versions.
 
 ### Evergreen Bleeding Edge
 
-`edge` is the absolute latest product version and image features, with zero guarantees for stability.
-Typically, this is only attractive to Ping employees or partners.
+The `edge` is the absolute latest product version and image features, with zero guarantees for stability.
+Typically, this tag is only of interest to Ping employees and partners.
 
 ## Base Release Tags
 
-The base release tags for a build are:
+The base release tags for a product image build are:
 
 * edge
 * latest
@@ -58,43 +63,46 @@ The base release tags for a build are:
 
 ### edge
 
-The `edge` release tag refers to "bleeding edge", indicating a build similar to an alpha release. This _sliding_ tag includes the absolute latest hooks and scripts, but is considered highly unstable. The `edge` release is characterized by:
+The `edge` release tag refers to "bleeding edge", indicating a build similar to an alpha release. This _sliding_ tag includes the latest hooks and scripts, **and is considered highly unstable**. The `edge` release is characterized by:
 
 * Latest product version
-* Latest build image enhancements and fixes from our current sprint
-* Runs on the Linux Alpine OS
+* Latest build image enhancements and fixes from our current sprint in progress
+* Linux Alpine as the container base OS
 
-Example: `pingidentity/pingfederate:edge`, `pingidentity/pingfederate:10.2.2-edge`.
+Example: `pingidentity/pingfederate:edge`, `pingidentity/pingfederate:11.1.0-edge`
 
 ### latest
 
-`edge `is tagged as `latest` at the beginning of each month. The release tag indicates the latest stable release. This is a _sliding_ tag that marks the stable release for the latest sprint. The `latest` release is characterized by:
+`edge `is tagged as `latest` at the beginning of each month. The release tag indicates the latest stable release. This tag is also a _sliding_ tag that marks the stable release for the latest sprint. The `latest` release is characterized by:
 
 * Latest product version
 * All completed and qualified enhacements and fixes from the prior monthly sprint
-* Runs on the Linux Alpine OS
+* Linux Alpine as the container base OS
 
-Example: `pingfederate:latest`, `pingfederate:10.2.2-latest`
+Example: `pingfederate:latest`, `pingfederate:11.1.0-latest`
 
 ### sprint
 
-In addition to becoming `latest`, `edge` also is tagged as a stable `sprint` each month.  The `sprint` release tag is a build number indicating a stable build that won't change. The `sprint` number uses the YYMM format. For example, 2201 = January 2022.  The `latest` release is characterized by:
+In addition to becoming `latest`, `edge` also is tagged as a stable `sprint` each month.  The `sprint` release tag is a build number indicating a stable build that will not change over time. The `sprint` number uses the YYMM format. For example, 2208 = August 2022.  The `sprint` release is characterized by:
 
 * Latest product version at the time the sprint ended.
-* All completed and qualified enhacements and fixes from the specified monthly sprint. The Docker images are generated at the end of the specified monthly sprint.
-* Runs on the Linux Alpine OS.
+* All completed and qualified enhancements and fixes from the specified monthly sprint. The Docker images are generated at the end of the sprint.
+* Linux Alpine as the container base OS
 
-Example: `pingfederate:2103`, `pingidentity/pingfederate:2103-10.2.2`
+Example: `pingfederate:2206`, `pingidentity/pingfederate:2206-11.1.0`
 
 ### sprint (point release)
 
-Occasionally, a bug might be found on a stable release. To avoid changing a `sprint` tag, a point release would be pushed to move `latest` forward.
+Occasionally, a bug might be found on a stable release, whether in the product itself or something from the team building the image. In these situations, to avoid changing a `sprint` tag which is promised to be immutable, a point release would be created to move `latest` forward.  
 
-Example: `pingfederate:2103.1`, `pingidentity/pingfederate:2103.1-10.2.2`
+!!! note "Example only"
+    These example tags do not exist, they are used here only for illustration purposes.
 
-## Determine Image Product Version
+Example: `pingfederate:2206.1`, `pingidentity/pingfederate:2206.1-11.1.0`
 
-If you're unsure of the product version for the container you are running, shell into the container, then echo the $IMAGE_VERSION environment variable. For example:
+## Determine Image Version
+
+If you are unsure of the exact version of the image used for a given product container, shell into the container and examine the $IMAGE_VERSION environment variable. For example, if you are running a container locally under Docker, you would run the following commands:
 
 ```sh
 docker container exec -it <container id> sh
@@ -110,19 +118,21 @@ The IMAGE_VERSION variable returns the version in this format:
 For example:
 
 ```sh
-IMAGE_VERSION=pingcentral-alpine-az11-1.3.0-200629-bc33
+IMAGE_VERSION=pingdirectory-alpine_3.16.0-al11-9.1.0.0-220725-c917
 ```
 
 Where:
 
 | Key | Value |
 |-----|-----|
-| Product | pingcentral |
-| Container OS | alpine |
-| JDK | az11 |
-| Product Version | 1.3.0 |
-| Build Date | 200629 |
-| Git Revision | bc33 |
+| Product | pingdirectory |
+| Container OS | alpine_3.16.0 |
+| JDK | al11 |
+| Product Version | 9.1.0.0 |
+| Build Date | 220725 |
+| Git Revision | c917 |
+
+If the container is running under Kubernetes, use the [kubectl exec](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#exec) command to access the container in order to obtain this information.
 
 !!! note "Date Format"
-    Date is in YYMMDD format
+    In the $IMAGE_VERSION variable, Date is in YYMMDD format


### PR DESCRIPTION
Closes BRASS-500

- Added paragraph to images landing page with link to tagging page
- edits/refinement on tagging documentation, updating the examples to more recent products/sprints
- re-emphasis on image removal process 