### PR TITLE
closes BRASS-558

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,6 @@ title: Welcome
 ---
 # Welcome
 
-!!! error "Significant Portal Changes July 2022"
-    Based on feedback and deprecated examples, this portal received a significant number of changes in July 2022.  See [this page](./home/portalUpdates.md) for details.
-
 This documentation exists to enable DevOps professionals, administrators, and developers to deploy Ping Identity software using container technologies. Our goal is to provide tools, frameworks, blueprints, and reference architectures in support of running our products in containerized environments.
 
 * First time here?  We recommend the [Get Started](./get-started/introduction.md) page.

--- a/docs/get-started/getStartedExample.md
+++ b/docs/get-started/getStartedExample.md
@@ -3,11 +3,8 @@ title: Deploy an Example Stack
 ---
 # Deploy an Example Stack
 
-!!! warning "Orchestration note"
-    In the past, Docker Compose was used for many of our product container examples.  We are no longer maintaining or supporting Docker Compose, and recommend the use of the Ping Helm charts for working with Ping products in a containerized model.
-
 !!! note "Networking"
-    This example was written using Docker Desktop with Kubernetes enabled on the Mac platform.  The version used for this guide was `4.11.1(84025)`, which includes Docker Engine `v20.10.17` and Kubernetes `v1.24.2`.  The ingress-nginx controller version was `1.3.0`.
+    This example was written using Docker Desktop with Kubernetes enabled on the Mac platform.  The version used for this guide was `4.12.0(85629)`, which includes Docker Engine `v20.10.17` and Kubernetes `v1.25.0`.  The ingress-nginx controller version was `1.3.0`.
 
 !!! note "Kubernetes Services Kubernetes versus Server-Deployed Applications"
 

--- a/docs/home/portalUpdates.md
+++ b/docs/home/portalUpdates.md
@@ -1,5 +1,5 @@
 # Recent portal updates
-This page provides details on recent significant changes to this portal.
+This page provides details on significant changes to this portal.
 
 # July 2022
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,7 +83,7 @@ nav:
       - License: "home/license.md"
       - Disclaimer: "home/disclaimer.md"
       - Third-Party Software:  "home/3rdPartySoftware.md"
-      - Recent portal updates: "home/portalUpdates.md"
+      - Portal updates: "home/portalUpdates.md"
   - Ping Docker Images:
       - Introduction: "docker-images/dockerImagesRef.md"
       - Product Images:


### PR DESCRIPTION
- Clean up the "significant changes" blurb and "recent" references
- Updated the getting-started example to latest Docker Desktop (confirmed it worked through testing)
- Renamed "Recent Portal Updates" navigation to simply "Portal updates"