### PR TITLE
BRASS-688: Fix Existing License Mount Documentation

### DIFF
--- a/docs/how-to/existingLicense.md
+++ b/docs/how-to/existingLicense.md
@@ -11,15 +11,16 @@ The `/opt/in` directory overlays files onto the products runtime filesystem, the
 
 ### Example Mounts
 
-|  Product | File Name  |  Mount Path |
-|---|---|---|
-| **PingFederate**  | pingfederate.lic  |  /opt/in/instance/server/default/conf/pingfederate.lic |
-| **PingAccess** | pingaccess.lic  | /opt/in/instance/conf/pingaccess.lic  |
-| **PingDirectory** | PingDirectory.lic  | /opt/staging/pd.profile/server-root/pre-setup/PingDirectory.lic  |
-| **PingDataSync** | PingDirectory.lic  | /opt/staging/pd.profile/server-root/pre-setup/PingDirectory.lic  |
-| **PingAuthorize** | PingAuthorize.lic  | /opt/staging/pd.profile/server-root/pre-setup/PingAuthorize.lic  |
-| **PingAuthorize PAP** | PingAuthorize.lic  | /opt/staging/pd.profile/server-root/pre-setup/PingAuthorize.lic  |
-| **PingCentral** | pingcentral.lic  | /opt/in/instance/conf/pingcentral.lic  |
+| Product                | File Name  | Mount Path                                                 |
+|------------------------|---|------------------------------------------------------------|
+| **PingFederate**       | pingfederate.lic  | /opt/in/instance/server/default/conf/pingfederate.lic      |
+| **PingAccess**         | pingaccess.lic  | /opt/in/instance/conf/pingaccess.lic                       |
+| **PingDirectory**      | PingDirectory.lic  | /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic |
+| **PingDirectoryProxy** | PingDirectory.lic  | /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic |
+| **PingDataSync**       | PingDirectory.lic  | /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic |
+| **PingAuthorize**      | PingAuthorize.lic  | /opt/in/pd.profile/server-root/pre-setup/PingAuthorize.lic |
+| **PingAuthorize PAP**  | PingAuthorize.lic  | /opt/in/pd.profile/server-root/pre-setup/PingAuthorize.lic |
+| **PingCentral**        | pingcentral.lic  | /opt/in/instance/conf/pingcentral.lic                      |
 
 ### Volume Mount Syntax
 


### PR DESCRIPTION
- Advise use of /opt/in on all license mounts
- Add PingDirectoryProxy to the list of license mount locations for clarity.