### PR TITLE
Fix #375

### DIFF
--- a/99-helper-scripts/ping-bulkconfigtool/ping-bulkexport-tools-project/src/main/java/com/pingidentity/apac/pf/bulkconfigtools/App.java
+++ b/99-helper-scripts/ping-bulkconfigtool/ping-bulkexport-tools-project/src/main/java/com/pingidentity/apac/pf/bulkconfigtools/App.java
@@ -228,7 +228,6 @@ public class App {
 
 					if (value == null || value.equals("") || jsonValue.equals(value) || jsonValue.matches(value)) {
 						System.out.println("Ignoring " + key + ":" + value);
-						throw new RemoveNodeException();
 					}
 				}
 


### PR DESCRIPTION
#375 was closed despite not being fixed and the documentation not being accurate.

The tool still crashes with the same error using posted minimal config `.json`, and it's led to inaccurate documentation as well (you don't need empty json fields, not to mention that the posted "fix" doesn't even include _all_ the potential keys).

**Removing the uncaught/unused exception is enough to fix this problem.**

The entire parent function is only used to print a log line. It could also be entirely removed and the log line can be moved to inside the _real_ try/catch that performs the json node removal here: https://github.com/pingidentity/pingidentity-devops-getting-started/blob/master/99-helper-scripts/ping-bulkconfigtool/ping-bulkexport-tools-project/src/main/java/com/pingidentity/apac/pf/bulkconfigtools/App.java#L161