### PR TITLE
Fix example backup script being unable to run

### DIFF
--- a/30-helm/pingdirectory-backup/pingdirectory-periodic-backup.yaml
+++ b/30-helm/pingdirectory-backup/pingdirectory-periodic-backup.yaml
@@ -33,23 +33,7 @@ configMaps:
         #!/bin/sh
         set -e
 
-        # Determine if this is the master of the topology
-        _instanceName=$(dsconfig get-global-configuration-prop \
-          --property instance-name \
-          --script-friendly |
-          awk '{ print $2 }')
-        _masterInstanceName=$(ldapsearch \
-          --terse \
-          --outputFormat json\
-          --baseDN "cn=Mirrored subtree manager for base DN cn_Topology_cn_config,cn=monitor" \
-          --searchScope base \
-          objectclass=* \
-          master-instance-name | jq -r .attributes[].values[])
-
-        if test "${_instanceName}" != "${_masterInstanceName}"; then
-          echo "This instance is not the master instance. Not running backup on this instance."
-          exit 0
-        fi
+        # This script assumes it is only being run on a single pod of the topology
 
         # Create a directory for the backup
         mkdir -p /opt/pingdirectory-backup


### PR DESCRIPTION
Fix an issue with the PingDirectory example backup script not running due to the master pod not being the pod with ordinal 0 in the StatefulSet. The backup script has been updated to not check if the current pod is the topology master.

BRASS-1088