### PR TITLE
Add Vault CSI provider example for Secrets Store CSI Driver

### DIFF
--- a/30-helm/vault-spc/README.md
+++ b/30-helm/vault-spc/README.md
@@ -1,0 +1,44 @@
+# Secrets Store CSI Driver with HashiCorp Vault
+
+This example deploys PingDirectory and PingFederate with all secrets sourced from HashiCorp Vault via the [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/).
+
+The two products use different delivery mechanisms intentionally:
+
+| Product | Mechanism | How it works |
+|---------|-----------|--------------|
+| PingDirectory | Mounted files | Secrets written to `/run/secrets`; startup scripts source them automatically |
+| PingFederate (admin + engine) | Environment variables | `secretObjects` syncs secrets into a Kubernetes `Secret`; `container.envFrom` injects them as env vars |
+
+See the full walkthrough at `docs/vault-spc-walkthrough.adoc` for step-by-step instructions including cluster setup, Vault installation, secret seeding, and Kubernetes auth configuration.
+
+## Quick start
+
+After completing the setup steps in the walkthrough:
+
+```bash
+helm install ping pingidentity/ping-devops \
+  -n ping \
+  -f ping-values.yaml
+```
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `ping-values.yaml` | Helm values for the full deployment |
+
+## Verify
+
+**PingDirectory — secrets as files:**
+```bash
+kubectl exec -n ping \
+  $(kubectl get pod -n ping -l app.kubernetes.io/name=pingdirectory -o name | head -1) \
+  -- ls /run/secrets
+```
+
+**PingFederate — secrets as environment variables:**
+```bash
+kubectl exec -n ping \
+  $(kubectl get pod -n ping -l app.kubernetes.io/name=pingfederate-admin -o name | head -1) \
+  -- env | grep -E 'ADMINISTRATOR_PASSWORD|PING_IDENTITY_DEVOPS'
+```

--- a/30-helm/vault-spc/ping-values.yaml
+++ b/30-helm/vault-spc/ping-values.yaml
@@ -1,0 +1,138 @@
+# Deploy PingDirectory (file-based secrets) and PingFederate (env var secrets)
+# using the Secrets Store CSI Driver with HashiCorp Vault as the provider.
+#
+# See the walkthrough at docs/vault-spc-walkthrough.adoc for full setup steps,
+# including installing the CSI driver, deploying Vault, seeding secrets, and
+# configuring Kubernetes auth.
+#
+# Prerequisites:
+#   - Secrets Store CSI Driver installed in kube-system (syncSecret.enabled=true)
+#   - Vault deployed in the vault namespace with the CSI provider enabled
+#   - Vault seeded with secrets at ping/devops, ping/pingdirectory, ping/pingfederate
+#   - Kubernetes auth configured with a ping-role bound to the ping-vault-auth ServiceAccount
+#   - Namespace and ServiceAccount created:
+#       kubectl create namespace ping
+#       kubectl create serviceaccount ping-vault-auth -n ping
+
+global:
+  rbac:
+    serviceAccountName: ping-vault-auth
+
+# ---------------------------------------------------------------------------
+# PingDirectory: file-based secret delivery
+#
+# The CSI driver writes each fetched secret as a file under /run/secrets.
+# The Ping container startup scripts scan that directory at boot and source
+# any file whose name matches a known variable (PING_IDENTITY_DEVOPS_USER,
+# ROOT_USER_PASSWORD, etc.).  No Kubernetes Secret or envFrom is required.
+# ---------------------------------------------------------------------------
+pingdirectory:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingdirectory
+  secretProviderClass:
+    enabled: true
+    create: true
+    provider: vault
+    parameters:
+      vaultAddress: http://vault.vault:8200
+      roleName: ping-role
+      objects: |
+        - objectName: "PING_IDENTITY_DEVOPS_USER"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_USER"
+        - objectName: "PING_IDENTITY_DEVOPS_KEY"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_KEY"
+        - objectName: "ROOT_USER_PASSWORD"
+          secretPath: "ping/data/pingdirectory"
+          secretKey: "ROOT_USER_PASSWORD"
+        - objectName: "ROOT_USER_DN"
+          secretPath: "ping/data/pingdirectory"
+          secretKey: "ROOT_USER_DN"
+
+# ---------------------------------------------------------------------------
+# PingFederate admin: environment variable delivery via Kubernetes Secret sync
+#
+# secretObjects instructs the CSI driver to create a Kubernetes Secret whose
+# keys mirror the mounted files.  container.envFrom then injects that Secret
+# as environment variables.  The files are still written to /run/secrets, but
+# the product reads configuration from env vars instead.
+# ---------------------------------------------------------------------------
+pingfederate-admin:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingfederate
+  secretProviderClass:
+    enabled: true
+    create: true
+    provider: vault
+    parameters:
+      vaultAddress: http://vault.vault:8200
+      roleName: ping-role
+      objects: |
+        - objectName: "PING_IDENTITY_DEVOPS_USER"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_USER"
+        - objectName: "PING_IDENTITY_DEVOPS_KEY"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_KEY"
+        - objectName: "ADMINISTRATOR_PASSWORD"
+          secretPath: "ping/data/pingfederate"
+          secretKey: "ADMINISTRATOR_PASSWORD"
+    secretObjects:
+      - secretName: ping-pf-admin-env
+        type: Opaque
+        data:
+          - objectName: PING_IDENTITY_DEVOPS_USER
+            key: PING_IDENTITY_DEVOPS_USER
+          - objectName: PING_IDENTITY_DEVOPS_KEY
+            key: PING_IDENTITY_DEVOPS_KEY
+          - objectName: ADMINISTRATOR_PASSWORD
+            key: ADMINISTRATOR_PASSWORD
+  container:
+    envFrom:
+      - secretRef:
+          name: ping-pf-admin-env
+
+# ---------------------------------------------------------------------------
+# PingFederate engine: same env var pattern as admin
+# ---------------------------------------------------------------------------
+pingfederate-engine:
+  enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: getting-started/pingfederate
+  secretProviderClass:
+    enabled: true
+    create: true
+    provider: vault
+    parameters:
+      vaultAddress: http://vault.vault:8200
+      roleName: ping-role
+      objects: |
+        - objectName: "PING_IDENTITY_DEVOPS_USER"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_USER"
+        - objectName: "PING_IDENTITY_DEVOPS_KEY"
+          secretPath: "ping/data/devops"
+          secretKey: "PING_IDENTITY_DEVOPS_KEY"
+        - objectName: "ADMINISTRATOR_PASSWORD"
+          secretPath: "ping/data/pingfederate"
+          secretKey: "ADMINISTRATOR_PASSWORD"
+    secretObjects:
+      - secretName: ping-pf-engine-env
+        type: Opaque
+        data:
+          - objectName: PING_IDENTITY_DEVOPS_USER
+            key: PING_IDENTITY_DEVOPS_USER
+          - objectName: PING_IDENTITY_DEVOPS_KEY
+            key: PING_IDENTITY_DEVOPS_KEY
+          - objectName: ADMINISTRATOR_PASSWORD
+            key: ADMINISTRATOR_PASSWORD
+  container:
+    envFrom:
+      - secretRef:
+          name: ping-pf-engine-env


### PR DESCRIPTION
- to accompany updates to the helm chart due in release 0.12.3 (scheduled for May 2026)
- Demonstrates file-based (PingDirectory) and environment variable (PingFederate) secret delivery patterns in a single values file.
- OK to merge now pending the release of the chart and the walkthrough guide